### PR TITLE
update easy apply button selector

### DIFF
--- a/selectors/index.ts
+++ b/selectors/index.ts
@@ -1,5 +1,5 @@
 export default {
-  easyApplyButtonEnabled: "button.jobs-apply-button:enabled",
+  easyApplyButtonEnabled: "div.jobs-apply-button--top-card button.jobs-apply-button:enabled",
 
   // Job search form
   keywordInput: 'input[id*="jobs-search-box-keyword-id"]',


### PR DESCRIPTION
Easy apply button fix for new job offer page. Compatible with the job listing page.

It turns out there is a duplicate in the DOM, which is useless.